### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wulfland/Repstack/security/code-scanning/1](https://github.com/wulfland/Repstack/security/code-scanning/1)

In general, this problem is fixed by explicitly specifying a `permissions` block for the workflow or for individual jobs, limiting the `GITHUB_TOKEN` to the minimal scopes needed. For a typical CI workflow that only checks out code, installs dependencies, runs tests/builds, and uploads artifacts, `contents: read` is usually sufficient.

For this specific workflow in `.github/workflows/ci.yml`, the simplest and least invasive fix is to add a top-level `permissions` block (applies to all jobs) right after the `name: CI` header. The workflow steps do not modify repository contents or interact with issues/PRs beyond the standard `pull_request` trigger, and artifact upload does not require repo write permissions, so `contents: read` is adequate. No changes to steps, actions, or behavior are required—this only constrains the token’s capabilities.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  immediately after line 1 (`name: CI`).
- No imports, additional methods, or new files are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
